### PR TITLE
feat: Implement Mercado Libre deals endpoint

### DIFF
--- a/MLAPI/Controllers/DealsController.cs
+++ b/MLAPI/Controllers/DealsController.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Mvc;
+using MLAPI.Services;
+using MLAPI.Dtos;
+
+namespace MLAPI.Controllers;
+
+[ApiController]
+[Route("api/v1/deals")]
+public class DealsController : ControllerBase
+{
+    private readonly MercadoLibreApiClient _mercadoLibreApiClient;
+    private static readonly Dictionary<string, string> CategoryMappings = new()
+    {
+        { "laptops", "MLM1650" },
+        { "celulares", "MLM1051" },
+        { "videojuegos", "MLM1144" },
+        { "monitores", "MLM1652" }
+    };
+
+    public DealsController(MercadoLibreApiClient mercadoLibreApiClient)
+    {
+        _mercadoLibreApiClient = mercadoLibreApiClient;
+    }
+
+    [HttpGet("{categoryAlias}")]
+    public async Task<ActionResult<IEnumerable<MercadoLibreItemDto>>> GetDeals(string categoryAlias)
+    {
+        if (string.IsNullOrWhiteSpace(categoryAlias) || !CategoryMappings.TryGetValue(categoryAlias.ToLowerInvariant(), out var categoryId))
+        {
+            return BadRequest($"Invalid or unsupported category alias: {categoryAlias}. Supported aliases are: {string.Join(", ", CategoryMappings.Keys)}");
+        }
+
+        try
+        {
+            var deals = await _mercadoLibreApiClient.GetDealsByCategoryAsync(categoryId);
+            // Por ahora, DealDto es el mismo que MercadoLibreItemDto.
+            // Si se necesitara un mapeo a un DealDto específico para la respuesta, se haría aquí.
+            return Ok(deals);
+        }
+        catch (HttpRequestException ex)
+        {
+            // Log the exception (aquí solo lo imprimimos en consola)
+            Console.WriteLine($"Error calling MercadoLibre API: {ex.Message}");
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Error communicating with external service.");
+        }
+        catch (Exception ex)
+        {
+            // Log the exception
+            Console.WriteLine($"An unexpected error occurred: {ex.Message}");
+            return StatusCode(StatusCodes.Status500InternalServerError, "An unexpected error occurred.");
+        }
+    }
+}

--- a/MLAPI/Dtos/MercadoLibreItemDto.cs
+++ b/MLAPI/Dtos/MercadoLibreItemDto.cs
@@ -1,0 +1,10 @@
+namespace MLAPI.Dtos;
+
+public record MercadoLibreItemDto(
+    string Id,
+    string Title,
+    decimal Price,
+    string CurrencyId,
+    string Thumbnail,
+    string Permalink
+);

--- a/MLAPI/Program.cs
+++ b/MLAPI/Program.cs
@@ -7,6 +7,21 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Configuración para MercadoLibreApiClient
+var mercadoLibreApiConfig = builder.Configuration.GetSection("MercadoLibreApi");
+var baseAddress = mercadoLibreApiConfig["BaseUrl"];
+
+if (string.IsNullOrWhiteSpace(baseAddress))
+{
+    throw new InvalidOperationException("MercadoLibre API BaseUrl is not configured in appsettings.json.");
+}
+
+builder.Services.AddHttpClient<MLAPI.Services.MercadoLibreApiClient>(client =>
+{
+    client.BaseAddress = new Uri(baseAddress);
+});
+// Fin de configuración para MercadoLibreApiClient
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/MLAPI/Services/MercadoLibreApiClient.cs
+++ b/MLAPI/Services/MercadoLibreApiClient.cs
@@ -1,0 +1,55 @@
+using System.Net.Http.Json;
+using MLAPI.Dtos;
+
+namespace MLAPI.Services;
+
+// DTO para la estructura de respuesta de la API de búsqueda de Mercado Libre
+public class MercadoLibreSearchResponseDto
+{
+    public List<MercadoLibreItemDto> Results { get; set; } = new List<MercadoLibreItemDto>();
+}
+
+public class MercadoLibreApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public MercadoLibreApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        // La BaseAddress ya debería estar configurada desde Program.cs
+    }
+
+    public async Task<IEnumerable<MercadoLibreItemDto>> GetDealsByCategoryAsync(string categoryId)
+    {
+        if (string.IsNullOrWhiteSpace(categoryId))
+        {
+            throw new ArgumentException("Category ID cannot be null or whitespace.", nameof(categoryId));
+        }
+
+        // Endpoint: GET /sites/MLM/search?deal=yes&category={categoryId}&sort=price_asc
+        var requestUri = $"/sites/MLM/search?deal=yes&category={categoryId}&sort=price_asc";
+
+        try
+        {
+            var response = await _httpClient.GetAsync(requestUri);
+            response.EnsureSuccessStatusCode(); // Lanza una excepción si el código de estado no es exitoso.
+
+            // Deserializa la respuesta completa que contiene la lista "results"
+            var searchResponse = await response.Content.ReadFromJsonAsync<MercadoLibreSearchResponseDto>();
+
+            return searchResponse?.Results ?? Enumerable.Empty<MercadoLibreItemDto>();
+        }
+        catch (HttpRequestException ex)
+        {
+            // Aquí se podría registrar el error con un logger
+            Console.WriteLine($"Error fetching data from MercadoLibre API: {ex.Message}");
+            throw; // Relanzar para que el controlador pueda manejarlo o devolver un error apropiado
+        }
+        catch (JsonException ex)
+        {
+            // Registrar el error de deserialización
+            Console.WriteLine($"Error deserializing MercadoLibre API response: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/MLAPI/appsettings.json
+++ b/MLAPI/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "MercadoLibreApi": {
+    "BaseUrl": "https://api.mercadolibre.com"
+  }
 }


### PR DESCRIPTION
Implements the initial version of the deals endpoint as per Task #001.

Key changes include:
- Added MercadoLibreItemDto for Mercado Libre API responses.
- Configured Mercado Libre API base URL in appsettings.json.
- Implemented MercadoLibreApiClient to fetch deals by category from the Mercado Libre API (sites/MLM/search?deal=yes&category={categoryId}&sort=price_asc).
- Registered MercadoLibreApiClient and configured HttpClient in Program.cs.
- Created DealsController with a GET endpoint api/v1/deals/{categoryAlias} that maps category aliases to Mercado Libre category IDs and returns deals.
- Included initial category mappings for laptops, celulares, videojuegos, and monitores.